### PR TITLE
Add Dependabot grouping and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+---
+name: Dependabot Auto-Merge
+
+'on': pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-Merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7  # v2.3.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve and merge eligible updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/scripts/configure-branch-protection.sh
+++ b/scripts/configure-branch-protection.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="brianhartsock/ansible-role-smartmontools"
+BRANCH="master"
+REQUIRED_CHECKS=("Lint" "Molecule")
+
+CHECK_ONLY=false
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_ONLY=true
+fi
+
+echo "Repository: $REPO"
+echo "Branch: $BRANCH"
+echo "Required checks: ${REQUIRED_CHECKS[*]}"
+echo
+
+# Fetch current branch protection
+echo "=== Current Branch Protection ==="
+PROTECTION=$(gh api "repos/$REPO/branches/$BRANCH/protection" 2>/dev/null) || true
+
+if [[ -z "$PROTECTION" ]] || echo "$PROTECTION" | jq -e '.message == "Branch not protected"' &>/dev/null; then
+  echo "No branch protection currently configured."
+  CURRENT_CHECKS=()
+else
+  CURRENT_CHECKS_JSON=$(echo "$PROTECTION" | jq -r '.required_status_checks.contexts // []')
+  echo "Current required status checks:"
+  echo "$CURRENT_CHECKS_JSON" | jq -r '.[]' 2>/dev/null || echo "  (none)"
+  mapfile -t CURRENT_CHECKS < <(echo "$CURRENT_CHECKS_JSON" | jq -r '.[]' 2>/dev/null)
+fi
+
+echo
+echo "=== Check Analysis ==="
+MISSING=()
+for check in "${REQUIRED_CHECKS[@]}"; do
+  found=false
+  for current in "${CURRENT_CHECKS[@]:-}"; do
+    if [[ "$check" == "$current" ]]; then
+      found=true
+      break
+    fi
+  done
+  if $found; then
+    echo "  ✓ $check (already required)"
+  else
+    echo "  ✗ $check (missing)"
+    MISSING+=("$check")
+  fi
+done
+
+if [[ ${#MISSING[@]} -eq 0 ]]; then
+  echo
+  echo "All required checks are already configured. Nothing to do."
+  exit 0
+fi
+
+if $CHECK_ONLY; then
+  echo
+  echo "Run without --check to apply changes."
+  exit 1
+fi
+
+echo
+echo "=== Applying Branch Protection ==="
+
+# Build the checks array for the API
+CHECKS_JSON=$(printf '%s\n' "${REQUIRED_CHECKS[@]}" | jq -R . | jq -s .)
+
+gh api -X PUT "repos/$REPO/branches/$BRANCH/protection" \
+  --input - <<EOF
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": $CHECKS_JSON
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+
+echo "Branch protection updated."
+
+echo
+echo "=== Verification ==="
+VERIFY=$(gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks")
+echo "Required status checks now configured:"
+echo "$VERIFY" | jq -r '.contexts[]'


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to group all pip and github-actions updates into single weekly PRs per ecosystem
- Add `.github/workflows/dependabot-auto-merge.yml` to auto-approve and squash-merge patch/minor Dependabot PRs after CI passes (major updates require human review)
- Add `scripts/configure-branch-protection.sh` to configure required status checks (Lint, Molecule) on master so `--auto` merge waits for CI
- Branch protection has already been applied to the repo

## Test plan
- [ ] Verify Dependabot opens grouped PRs on next weekly run
- [ ] Verify auto-merge workflow triggers on Dependabot PRs and waits for CI
- [ ] Verify major version bumps are not auto-merged
- [ ] Run `./scripts/configure-branch-protection.sh --check` to confirm branch protection is in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)